### PR TITLE
bugfix, removed ambiguity

### DIFF
--- a/gendc_cpp/gendc_separator/ContainerHeader.h
+++ b/gendc_cpp/gendc_separator/ContainerHeader.h
@@ -113,7 +113,7 @@ public:
         return component_header_.at(ith_component).getDataOffset(jth_part);
     }
 
-    int64_t getDataSize(){
+    int64_t getContainerDataSize(){
         return DataSize_;
     }
 


### PR DESCRIPTION
Two getDataSize returned different values, so change the name.