### PR TITLE
Bugfix/typespecific InfoReserved_

### DIFF
--- a/gendc_cpp/gendc_separator/PartHeader.h
+++ b/gendc_cpp/gendc_separator/PartHeader.h
@@ -58,12 +58,15 @@ public:
         if (num_typespecific_ > 1){
             offset += read(header_info, offset, Padding_[0]);
             offset += read(header_info, offset, Padding_[1]);
-            TypeSpecific_.push_back((static_cast<int64_t>(Padding_[0]) << 16) + static_cast<int64_t>(Padding_[1]));
-        }
-        if (num_typespecific_ > 2){
             offset += sizeof(InfoReserved_);
-            TypeSpecific_.push_back(static_cast<int64_t>(InfoReserved_));
+            TypeSpecific_.push_back(
+                (static_cast<int64_t>(Padding_[0]) << 48) 
+                + (static_cast<int64_t>(Padding_[1]) << 32)
+                + static_cast<int64_t>(InfoReserved_)
+                );
         }
+
+        // if num_typespecific_ > 2
         int64_t typespecific_item;
         for (int i = 0; i < num_typespecific_ - 2; ++i){
             offset += read(header_info, offset, typespecific_item);

--- a/gendc_python/__init__.py
+++ b/gendc_python/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.2.5'
+__version__ = '0.2.6'
 from . import gendc_separator

--- a/gendc_python/gendc_separator/part.py
+++ b/gendc_python/gendc_separator/part.py
@@ -35,10 +35,13 @@ class Part:
                 set_offset(self.header, key, part_cursor + get_offset(self.header, key))
             set_value(self.header, key, load_from_binary(self.header, binary_info, key))
 
+        # this num_typespecific includes Dimension, Padding and InfoReserved  
         num_typespecific = int((get_value(self.header, "HeaderSize") - 40) / 8)
 
+        # setup typespecific offset for Dimension and Padding with InfoReserved (optinoal) 
         typespecific_offsets = [part_cursor + 40 + 8 * i for i in range(min(2,num_typespecific))]
-        typespecific_offsets.extend([part_cursor + 52 + 4 * i for i in range(num_typespecific-2)])
+        # setup typespecific offset the other (optinoal)
+        typespecific_offsets.extend([part_cursor + 56 + 8 * i for i in range(num_typespecific-2)])
 
         set_offset(self.header, "TypeSpecific", typespecific_offsets)
         set_value(self.header, "TypeSpecific", load_from_binary(self.header, binary_info, "TypeSpecific"))

--- a/gendc_python/gendc_separator/part.py
+++ b/gendc_python/gendc_separator/part.py
@@ -38,10 +38,8 @@ class Part:
         # this num_typespecific includes Dimension, Padding and InfoReserved  
         num_typespecific = int((get_value(self.header, "HeaderSize") - 40) / 8)
 
-        # setup typespecific offset for Dimension and Padding with InfoReserved (optinoal) 
-        typespecific_offsets = [part_cursor + 40 + 8 * i for i in range(min(2,num_typespecific))]
-        # setup typespecific offset the other (optinoal)
-        typespecific_offsets.extend([part_cursor + 56 + 8 * i for i in range(num_typespecific-2)])
+        # setup typespecific offset for <Dimension> and <Padding with InfoReserved> (optinoal) 
+        typespecific_offsets = [part_cursor + 40 + 8 * i for i in range(num_typespecific)]
 
         set_offset(self.header, "TypeSpecific", typespecific_offsets)
         set_value(self.header, "TypeSpecific", load_from_binary(self.header, binary_info, "TypeSpecific"))


### PR DESCRIPTION
Before change:
```
--------+--------+--------+--------
 dimension[0]    | dimension[1]
--------+--------+--------+--------
 px     | py     | 
--------+--------+--------+--------
 inforeserved    |
--------+--------+--------+--------
 framecount      |
```

After change:
```
--------+--------+--------+--------
 dimension[0]    | dimension[1]
--------+--------+--------+--------
 px     | py     | inforeserved
--------+--------+--------+--------
 framecount      |
```

reference: 
https://www.emva.org/wp-content/uploads/GenICam_GenDC_v1_1.pdf