### PR TITLE
removed the warning

### DIFF
--- a/gendc_cpp/gendc_separator/ContainerHeader.h
+++ b/gendc_cpp/gendc_separator/ContainerHeader.h
@@ -77,11 +77,11 @@ public:
         return DescriptorSize_;
     }
 
-    int32_t getContainerSize(){
+    int64_t getContainerSize(){
         return DescriptorSize_ + DataSize_;
     }
 
-    int32_t getDataSize(){
+    int64_t getDataSize(){
         return DataSize_;
     }
 

--- a/gendc_cpp/gendc_separator/PartHeader.h
+++ b/gendc_cpp/gendc_separator/PartHeader.h
@@ -157,7 +157,7 @@ public:
     }
 
     int32_t getOffsetofTypeSpecific(int32_t kth_typespecific, int32_t typespecific_offset = 0){
-        return offset_ +  DEFAULT_PART_HEADER_SIZE + 8 * (kth_typespecific - 1) + typespecific_offset;
+        return static_cast<int32_t>(offset_) +  DEFAULT_PART_HEADER_SIZE + 8 * (kth_typespecific - 1) + typespecific_offset;
     }
 
     int64_t getTypeSpecificByIndex(int32_t kth_typespecific ){
@@ -235,7 +235,7 @@ private:
 
 
     int32_t num_typespecific_;
-    int32_t offset_ = 0; // currently part header offset
+    size_t offset_ = 0; // currently part header offset
     char * part_;
 };
 // }

--- a/test/CMAKELists.txt
+++ b/test/CMAKELists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.3)
+project(SensingDevGenDC)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(GENDC_SEPARATOR ../gendc_cpp)
+
+include_directories(${GENDC_SEPARATOR}/gendc_separator)
+add_executable(test test.cpp)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -26,7 +26,19 @@ const int64_t DATASIZE[9] = {2073600, 3200, 32, 32, 32, 96, 0, 0, 0};
 const int32_t FORMAT[9] = {Mono8, Data16, Data16, Data16, Data16, Data16, Data8, Data8, Data8};
 const std::string DIMENSION[9] = {"1920x1080", "800", "16", "16", "16", "16", "0", "0", "0"};
 
+#ifdef _WIN32
+
+#include <Windows.h>
+#include <stdio.h>
+#include <filesystem>
+#define PATH_MAX 4096
+
+#else
+
 #include <unistd.h>
+
+#endif
+
 #include <iostream>
 #include <string>
 #include <limits.h>
@@ -39,6 +51,20 @@ const std::string DIMENSION[9] = {"1920x1080", "800", "16", "16", "16", "16", "0
 #include <iomanip>
 
 std::string GetExecutableDir() {
+#ifdef _WIN32
+    char exePath[MAX_PATH];
+    GetModuleFileNameA(NULL, exePath, PATH_MAX);
+
+    if (exePath){
+        std::string str(exePath);
+        std::filesystem::path path(str);
+        // Note: assume it is built under build directory i.e. test\\build\\Release\\test.exe
+        std::filesystem::path release_dir = path.parent_path();
+        std::filesystem::path test_dir = release_dir.parent_path().parent_path();
+        return test_dir.string();
+    }
+    return "";
+#else
     char path[PATH_MAX];
     ssize_t len = readlink("/proc/self/exe", path, sizeof(path) - 1);
     if (len != -1) {
@@ -48,6 +74,7 @@ std::string GetExecutableDir() {
         return (std::string::npos == pos) ? "" : executable_path.substr(0, pos);
     }
     return "";
+#endif
 }
 
 template <typename T>


### PR DESCRIPTION
Fixed the type mismatch on API. 

* getContainerSize()
* getDataSize()

now returns int64_t which are the original size defined on GenDC https://www.emva.org/wp-content/uploads/GenICam_GenDC_v1_1.pdf