### PR TITLE
Fix glib to 2.72

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -142,7 +142,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-release-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-         os: [ubuntu-latest, macos-latest, windows-latest]
+         os: [ubuntu-22.04, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
 
   upload-test-pypi:
     needs: [build_wheels]
-    runs-on:  ubuntu-latest
+    runs-on:  ubuntu-22.04
     environment: pypi
     permissions:
       id-token: write
@@ -85,7 +85,7 @@ jobs:
    runs-on: ${{ matrix.os }}
    strategy:
      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
 
    steps:
    - uses: actions/checkout@v4
@@ -100,7 +100,7 @@ jobs:
 
   upload_PYPI:
     needs: [ test_TEST_PYPI ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: pypi
     permissions:
       id-token: write


### PR DESCRIPTION
~~github image updated apt repository so manually downgrade to jammy-updates~~ set ubuntu image 22.04 instead of latest makes apt repository jammy updates