### PR TITLE
Fix/ gst-license

### DIFF
--- a/gst/meson.build
+++ b/gst/meson.build
@@ -3,7 +3,7 @@ plugin_c_args = ['-DHAVE_CONFIG_H']
 cdata = configuration_data()
 cdata.set_quoted('PACKAGE_VERSION', full_version)
 cdata.set_quoted('PACKAGE', 'gendc-separator')
-cdata.set_quoted('GST_LICENSE', 'MIT')
+cdata.set_quoted('GST_LICENSE', 'LGPL')
 cdata.set_quoted('GST_PACKAGE_NAME', 'GenDC Separator')
 cdata.set_quoted('GST_PACKAGE_ORIGIN', 'https://github.com/Sensing-Dev/')
 configure_file(output : 'config.h', configuration : cdata)

--- a/gst/src/gstgendcseparator.c
+++ b/gst/src/gstgendcseparator.c
@@ -72,8 +72,6 @@ static GstStaticPadTemplate component_src_factory = GST_STATIC_PAD_TEMPLATE ("co
 #define gst_gendc_separator_parent_class parent_class
 G_DEFINE_TYPE (GstGenDCSeparator, gst_gendc_separator, GST_TYPE_ELEMENT);
 
-GST_ELEMENT_REGISTER_DEFINE (gendc_separator, "gendcseparator", GST_RANK_NONE,
-    GST_TYPE_GENDCSEPARATOR);
 
 static void gst_gendc_separator_set_property (GObject * object,
     guint prop_id, const GValue * value, GParamSpec * pspec);


### PR DESCRIPTION
## MIT license is not allowed
`0:00:00.004974018 436241 0xaaaad8503400 WARN      GST_PLUGIN_LOADING gstplugin.c:501:gst_plugin_register_func: plugin "/home/xinyu/GenDC/install/gendc/lib/aarch64-linux-gnu/gstreamer-1.0/libgstgendcseparator.0.4.so" has invalid license "MIT", not loading`

Use LGPL instead of MIT for gst plugin
https://gstreamer.freedesktop.org/documentation/plugin-development/appendix/licensing-advisory.html?gi-language=c

